### PR TITLE
Allow value placeholder in custom error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The filter specification for a single field is also an array.  It can contain tw
   `defaultRequired` option.
 * `default` defines what the default value of this field is if none is given.  A field with a default value will be guaranteed to be in the
   result.  The `required` value does not affect `default` behavior.
+* `error` defines a custom error message to be returned if the value fails filtering. Within the error string, `{value}` can be used as a placeholder
+  for the value that failed filtering.
 
 The rest of the specification for the field are the filters to apply.
 

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -379,14 +379,13 @@ final class Filterer
         $error = $customError;
         if ($error === null) {
             $error = sprintf(
-                "Field '%s' with value '%s' failed filtering, message '%s'",
+                "Field '%s' with value '{value}' failed filtering, message '%s'",
                 $field,
-                trim(var_export($value, true), "'"),
                 $e->getMessage()
             );
         }
 
-        $errors[] = $error;
+        $errors[] = str_replace('{value}', trim(var_export($value, true), "'"), $error);
         return $errors;
     }
 

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -418,6 +418,26 @@ final class FiltererTest extends TestCase
     }
 
     /**
+     * @test
+     * @covers ::filter
+     */
+    public function filterWithCustomErrorContainingValuePlaceholder()
+    {
+        $result = Filterer::filter(
+            [
+                'fieldOne' => [
+                    'error' => "The value '{value}' is invalid.",
+                    ['uint'],
+                ],
+            ],
+            ['fieldOne' => 'abc']
+        );
+        $this->assertSame(
+            [false, null, "The value 'abc' is invalid.", []],
+            $result
+        );
+    }
+    /**
      * Verify behavior of filter() when 'error' is not a string value.
      *
      * @test


### PR DESCRIPTION
## What does this PR do?
This pull request allows a user to put a placeholder in the custom error message
#### Example

```php
use TraderInteractive\Filterer;                                                                                         
$filters = [                                                                                                            
    'field' => [                                                                                                        
        'error' => "The value '{value}' is not a valid unsigned integer.",                                                                   
        ['uint'],                                                                                                       
    ],                                                                                                                  
];                                                                                                                      
$result = Filterer::filter($filters, ['field' => 'abc']);                                                               
var_dump($result);
```
#### Output

```sh
array(4) {
  [0] =>
  bool(false)
  [1] =>
  NULL
  [2] =>
  string(27) "The value 'abc' is not a valid unsigned integer."
  [3] =>
  array(0) {
  }
}
```
## Checklist

- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [x] Relevant documentation produced and/or updated

