### PR TITLE
Add Filterer responseType option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.0",
+        "traderinteractive/exceptions": "^1.2",
         "traderinteractive/filter-arrays": "^3.1",
         "traderinteractive/filter-bools": "^3.0",
         "traderinteractive/filter-dates": "^3.0",

--- a/src/FilterResponse.php
+++ b/src/FilterResponse.php
@@ -58,21 +58,4 @@ final class FilterResponse
 
         throw new InvalidArgumentException("Property '{$name}' does not exist");
     }
-
-    /**
-     * Converts the response to an array.
-     *
-     * @return array
-     */
-    public function toArray() : array
-    {
-        $filteredValue = $this->success ? $this->filteredValue : null;
-
-        return [
-            $this->success,
-            $filteredValue,
-            $this->errorMessage,
-            $this->unknowns
-        ];
-    }
 }

--- a/src/FilterResponse.php
+++ b/src/FilterResponse.php
@@ -2,6 +2,8 @@
 
 namespace TraderInteractive;
 
+use TraderInteractive\Exceptions\ReadOnlyViolationException;
+
 /**
  * This object contains the various data returned by a filter action.
  *
@@ -14,6 +16,11 @@ namespace TraderInteractive;
 final class FilterResponse
 {
     /**
+     * @var array
+     */
+    private $response;
+
+    /**
      * @param array $filteredValue The input values after being filtered.
      * @param array $errors        Any errors encountered during the filter process.
      * @param array $unknowns      The values that were unknown during filtering.
@@ -23,11 +30,24 @@ final class FilterResponse
         array $errors = [],
         array $unknowns = []
     ) {
-        $this->success = count($errors) === 0;
-        $this->filteredValue = $filteredValue;
-        $this->errors = $errors;
-        $this->errorMessage = $this->success ? null : implode("\n", $errors);
-        $this->unknowns = $unknowns;
+        $success = count($errors) === 0;
+        $this->response = [
+            'success' => $success,
+            'filteredValue' => $filteredValue,
+            'errors' => $errors,
+            'errorMessage' => $success ? null : implode("\n", $errors),
+            'unknowns' => $unknowns,
+        ];
+    }
+
+    public function __get($name)
+    {
+        return $this->response[$name];
+    }
+
+    public function __set($name, $value)
+    {
+        throw new ReadOnlyViolationException("Property {$name} is read-only");
     }
 
     /**

--- a/src/FilterResponse.php
+++ b/src/FilterResponse.php
@@ -2,16 +2,17 @@
 
 namespace TraderInteractive;
 
+use InvalidArgumentException;
 use TraderInteractive\Exceptions\ReadOnlyViolationException;
 
 /**
  * This object contains the various data returned by a filter action.
  *
- * @property-read bool        $success       TRUE if the filter was successful or FALSE if errors were encountered.
- * @property-read mixed       $filteredValue The input values after being filtered.
- * @property-read array       $errors        Any errors encountered during the filter process.
- * @property-read string|null $errorMessage  An error message generated from the errors. NULL if no errors.
- * @property-read mixed       $unknowns      The values that were unknown during filtering.
+ * @property bool        $success       TRUE if the filter was successful or FALSE if errors were encountered.
+ * @property mixed       $filteredValue The input values after being filtered.
+ * @property array       $errors        Any errors encountered during the filter process.
+ * @property string|null $errorMessage  An error message generated from the errors. NULL if no errors.
+ * @property mixed       $unknowns      The values that were unknown during filtering.
  */
 final class FilterResponse
 {
@@ -42,12 +43,20 @@ final class FilterResponse
 
     public function __get($name)
     {
-        return $this->response[$name];
+        if (array_key_exists($name, $this->response)) {
+            return $this->response[$name];
+        }
+
+        throw new InvalidArgumentException("Property '{$name}' does not exist");
     }
 
     public function __set($name, $value)
     {
-        throw new ReadOnlyViolationException("Property {$name} is read-only");
+        if (array_key_exists($name, $this->response)) {
+            throw new ReadOnlyViolationException("Property '{$name}' is read-only");
+        }
+
+        throw new InvalidArgumentException("Property '{$name}' does not exist");
     }
 
     /**

--- a/src/FilterResponse.php
+++ b/src/FilterResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TraderInteractive;
+
+/**
+ * This object contains the various data returned by a filter action.
+ *
+ * @property-read bool        $success       TRUE if the filter was successful or FALSE if errors were encountered.
+ * @property-read mixed       $filteredValue The input values after being filtered.
+ * @property-read array       $errors        Any errors encountered during the filter process.
+ * @property-read string|null $errorMessage  An error message generated from the errors. NULL if no errors.
+ * @property-read mixed       $unknowns      The values that were unknown during filtering.
+ */
+final class FilterResponse
+{
+    /**
+     * @param array $filteredValue The input values after being filtered.
+     * @param array $errors        Any errors encountered during the filter process.
+     * @param array $unknowns      The values that were unknown during filtering.
+     */
+    public function __construct(
+        array $filteredValue,
+        array $errors = [],
+        array $unknowns = []
+    ) {
+        $this->success = count($errors) === 0;
+        $this->filteredValue = $filteredValue;
+        $this->errors = $errors;
+        $this->errorMessage = $this->success ? null : implode("\n", $errors);
+        $this->unknowns = $unknowns;
+    }
+
+    /**
+     * Converts the response to an array.
+     *
+     * @return array
+     */
+    public function toArray() : array
+    {
+        $filteredValue = $this->success ? $this->filteredValue : null;
+
+        return [
+            $this->success,
+            $filteredValue,
+            $this->errorMessage,
+            $this->unknowns
+        ];
+    }
+}

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -134,10 +134,11 @@ final class Filterer
      */
     public static function filter(array $spec, array $input, array $options = [])
     {
-        $options += ['allowUnknowns' => false, 'defaultRequired' => false];
+        $options += ['allowUnknowns' => false, 'defaultRequired' => false, 'responseType' => self::RESPONSE_TYPE_ARRAY];
 
         $allowUnknowns = self::getAllowUnknowns($options);
         $defaultRequired = self::getDefaultRequired($options);
+        $responseType = $options['responseType'];
 
         $inputToFilter = array_intersect_key($input, $spec);
         $leftOverSpec = array_diff_key($spec, $input);
@@ -186,8 +187,6 @@ final class Filterer
         }
 
         $errors = self::handleAllowUnknowns($allowUnknowns, $leftOverInput, $errors);
-
-        $responseType = $options['responseType'] ?? self::RESPONSE_TYPE_ARRAY;
 
         return self::generateFilterResponse($responseType, $inputToFilter, $errors, $leftOverInput);
     }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -346,7 +346,7 @@ final class Filterer
     private static function checkForUnknowns(array $leftOverInput, array $errors) : array
     {
         foreach ($leftOverInput as $field => $value) {
-            $errors[] = "Field '{$field}' with value '" . trim(var_export($value, true), "'") . "' is unknown";
+            $errors[$field] = "Field '{$field}' with value '" . trim(var_export($value, true), "'") . "' is unknown";
         }
 
         return $errors;
@@ -364,7 +364,7 @@ final class Filterer
     private static function handleRequiredFields(bool $required, string $field, array $errors) : array
     {
         if ($required) {
-            $errors[] = "Field '{$field}' was required and not present";
+            $errors[$field] = "Field '{$field}' was required and not present";
         }
         return $errors;
     }
@@ -402,7 +402,7 @@ final class Filterer
             );
         }
 
-        $errors[] = str_replace('{value}', trim(var_export($value, true), "'"), $error);
+        $errors[$field] = str_replace('{value}', trim(var_export($value, true), "'"), $error);
         return $errors;
     }
 

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -489,7 +489,12 @@ final class Filterer
         }
 
         if ($responseType === self::RESPONSE_TYPE_ARRAY) {
-            return $filterResponse->toArray();
+            return [
+                $filterResponse->success,
+                $filterResponse->success ? $filterResponse->filteredValue : null,
+                $filterResponse->errorMessage,
+                $filterResponse->unknowns
+            ];
         }
 
         throw new InvalidArgumentException("'responseType' was not a recognized value");

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -3,6 +3,7 @@
 namespace TraderInteractive;
 
 use Exception;
+use InvalidArgumentException;
 use Throwable;
 use TraderInteractive\Exceptions\FilterException;
 
@@ -110,11 +111,11 @@ final class Filterer
      *     on error [false, null, 'error message', array of unknown fields]
      *
      * @throws Exception
-     * @throws \InvalidArgumentException if 'allowUnknowns' option was not a bool
-     * @throws \InvalidArgumentException if 'defaultRequired' option was not a bool
-     * @throws \InvalidArgumentException if filters for a field was not a array
-     * @throws \InvalidArgumentException if a filter for a field was not a array
-     * @throws \InvalidArgumentException if 'required' for a field was not a bool
+     * @throws InvalidArgumentException if 'allowUnknowns' option was not a bool
+     * @throws InvalidArgumentException if 'defaultRequired' option was not a bool
+     * @throws InvalidArgumentException if filters for a field was not an array
+     * @throws InvalidArgumentException if a filter for a field was not an array
+     * @throws InvalidArgumentException if 'required' for a field was not a bool
      */
     public static function filter(array $spec, array $input, array $options = []) : array
     {
@@ -319,7 +320,7 @@ final class Filterer
     private static function assertIfStringOrInt($alias)
     {
         if (!is_string($alias) && !is_int($alias)) {
-            throw new \InvalidArgumentException('$alias was not a string or int');
+            throw new InvalidArgumentException('$alias was not a string or int');
         }
     }
 
@@ -360,7 +361,7 @@ final class Filterer
     {
         $required = isset($filters['required']) ? $filters['required'] : $defaultRequired;
         if ($required !== false && $required !== true) {
-            throw new \InvalidArgumentException("'required' for field '{$field}' was not a bool");
+            throw new InvalidArgumentException("'required' for field '{$field}' was not a bool");
         }
 
         return $required;
@@ -369,7 +370,7 @@ final class Filterer
     private static function assertFiltersIsAnArray($filters, string $field)
     {
         if (!is_array($filters)) {
-            throw new \InvalidArgumentException("filters for field '{$field}' was not a array");
+            throw new InvalidArgumentException("filters for field '{$field}' was not a array");
         }
     }
 
@@ -414,7 +415,7 @@ final class Filterer
     private static function assertFilterIsNotArray($filter, string $field)
     {
         if (!is_array($filter)) {
-            throw new \InvalidArgumentException("filter for field '{$field}' was not a array");
+            throw new InvalidArgumentException("filter for field '{$field}' was not a array");
         }
     }
 
@@ -424,7 +425,7 @@ final class Filterer
         if (array_key_exists('error', $filters)) {
             $customError = $filters['error'];
             if (!is_string($customError) || trim($customError) === '') {
-                throw new \InvalidArgumentException("error for field '{$field}' was not a non-empty string");
+                throw new InvalidArgumentException("error for field '{$field}' was not a non-empty string");
             }
 
             unset($filters['error']);//unset so its not used as a filter
@@ -437,7 +438,7 @@ final class Filterer
     {
         $allowUnknowns = $options['allowUnknowns'];
         if ($allowUnknowns !== false && $allowUnknowns !== true) {
-            throw new \InvalidArgumentException("'allowUnknowns' option was not a bool");
+            throw new InvalidArgumentException("'allowUnknowns' option was not a bool");
         }
 
         return $allowUnknowns;
@@ -447,7 +448,7 @@ final class Filterer
     {
         $defaultRequired = $options['defaultRequired'];
         if ($defaultRequired !== false && $defaultRequired !== true) {
-            throw new \InvalidArgumentException("'defaultRequired' option was not a bool");
+            throw new InvalidArgumentException("'defaultRequired' option was not a bool");
         }
 
         return $defaultRequired;

--- a/tests/FilterResponseTest.php
+++ b/tests/FilterResponseTest.php
@@ -2,7 +2,9 @@
 
 namespace TraderInteractiveTest;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use TraderInteractive\Exceptions\ReadOnlyViolationException;
 use TraderInteractive\FilterResponse;
 
 /**
@@ -63,6 +65,45 @@ class FilterResponseTest extends TestCase
         $this->assertSame([], $response->errors);
         $this->assertSame(null, $response->errorMessage);
         $this->assertSame([], $response->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function gettingInvalidPropertyThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Property 'foo' does not exist");
+
+        $response = new FilterResponse([]);
+        $response->foo;
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function settingValidPropertyThrowsAnException()
+    {
+        $this->expectException(ReadOnlyViolationException::class);
+        $this->expectExceptionMessage("Property 'success' is read-only");
+
+        $response = new FilterResponse([]);
+        $response->success = false;
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function settingInvalidPropertyThrowsAnException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Property 'foo' does not exist");
+
+        $response = new FilterResponse([]);
+        $response->foo = false;
     }
 
     /**

--- a/tests/FilterResponseTest.php
+++ b/tests/FilterResponseTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace TraderInteractiveTest;
+
+use PHPUnit\Framework\TestCase;
+use TraderInteractive\FilterResponse;
+
+/**
+ * @coversDefaultClass \TraderInteractive\FilterResponse
+ */
+class FilterResponseTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function construct()
+    {
+        $value = ['foo' => 'bar'];
+        $errors = [];
+        $unknowns = ['other' => 'unknown'];
+
+        $response = new FilterResponse($value, $errors, $unknowns);
+
+        $this->assertSame(true, $response->success);
+        $this->assertSame($value, $response->filteredValue);
+        $this->assertSame($errors, $response->errors);
+        $this->assertSame(null, $response->errorMessage);
+        $this->assertSame($unknowns, $response->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function constructWithErrors()
+    {
+        $value = ['foo' => 'bar'];
+        $errors = ['something bad happened', 'and something else too'];
+        $unknowns = ['other' => 'unknown'];
+
+        $response = new FilterResponse($value, $errors, $unknowns);
+
+        $this->assertSame(false, $response->success);
+        $this->assertSame($value, $response->filteredValue);
+        $this->assertSame($errors, $response->errors);
+        $this->assertSame("something bad happened\nand something else too", $response->errorMessage);
+        $this->assertSame($unknowns, $response->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function constructDefault()
+    {
+        $input = ['filtered' => 'input'];
+
+        $response = new FilterResponse($input);
+
+        $this->assertSame(true, $response->success);
+        $this->assertSame($input, $response->filteredValue);
+        $this->assertSame([], $response->errors);
+        $this->assertSame(null, $response->errorMessage);
+        $this->assertSame([], $response->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::toArray
+     * @dataProvider provideToArray
+     *
+     * @param array $value    The filtered value to pass to the response.
+     * @param array $errors   The errors to pass to the response.
+     * @param array $unknowns The unknowns to pass to the response.
+     * @param array $expected The expected array value.
+     */
+    public function toArray(array $value, array $errors, array $unknowns, array $expected)
+    {
+        $response = new FilterResponse($value, $errors, $unknowns);
+        $arrayResponse = $response->toArray();
+
+        $this->assertSame($expected, $arrayResponse);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideToArray() : array
+    {
+        return [
+            'success' => [
+                'input' => ['foo' => 'bar'],
+                'errors' => [],
+                'unknowns' => ['other' => 'unknown'],
+                'expected' => [true, ['foo' => 'bar'], null, ['other' => 'unknown']],
+            ],
+            'failure' => [
+                'input' => ['foo' => 'bar'],
+                'errors' => ['something bad happened', 'and something else too'],
+                'unknowns' => ['other' => 'unknown'],
+                'expected' => [false, null, "something bad happened\nand something else too", ['other' => 'unknown']],
+            ],
+        ];
+    }
+}

--- a/tests/FilterResponseTest.php
+++ b/tests/FilterResponseTest.php
@@ -105,43 +105,4 @@ class FilterResponseTest extends TestCase
         $response = new FilterResponse([]);
         $response->foo = false;
     }
-
-    /**
-     * @test
-     * @covers ::toArray
-     * @dataProvider provideToArray
-     *
-     * @param array $value    The filtered value to pass to the response.
-     * @param array $errors   The errors to pass to the response.
-     * @param array $unknowns The unknowns to pass to the response.
-     * @param array $expected The expected array value.
-     */
-    public function toArray(array $value, array $errors, array $unknowns, array $expected)
-    {
-        $response = new FilterResponse($value, $errors, $unknowns);
-        $arrayResponse = $response->toArray();
-
-        $this->assertSame($expected, $arrayResponse);
-    }
-
-    /**
-     * @return array
-     */
-    public function provideToArray() : array
-    {
-        return [
-            'success' => [
-                'input' => ['foo' => 'bar'],
-                'errors' => [],
-                'unknowns' => ['other' => 'unknown'],
-                'expected' => [true, ['foo' => 'bar'], null, ['other' => 'unknown']],
-            ],
-            'failure' => [
-                'input' => ['foo' => 'bar'],
-                'errors' => ['something bad happened', 'and something else too'],
-                'unknowns' => ['other' => 'unknown'],
-                'expected' => [false, null, "something bad happened\nand something else too", ['other' => 'unknown']],
-            ],
-        ];
-    }
 }

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -5,7 +5,7 @@ namespace TraderInteractive;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use StdClass;
+use stdClass;
 use TraderInteractive\Exceptions\FilterException;
 
 /**
@@ -379,7 +379,7 @@ final class FiltererTest extends TestCase
     public function filterWithNonStringError()
     {
         Filterer::filter(
-            ['fieldOne' => [['strtoupper'], 'error' => new StdClass()]],
+            ['fieldOne' => [['strtoupper'], 'error' => new stdClass()]],
             ['fieldOne' => 'valueOne']
         );
     }
@@ -436,7 +436,7 @@ final class FiltererTest extends TestCase
     public function ofScalarsFail()
     {
         try {
-            Filterer::ofScalars(['1', [], new \StdClass], [['string']]);
+            Filterer::ofScalars(['1', [], new stdClass], [['string']]);
             $this->fail();
         } catch (FilterException $e) {
             $expected = <<<TXT
@@ -495,7 +495,7 @@ TXT;
     {
         try {
             Filterer::ofArrays(
-                [['key' => new \StdClass], ['key' => []], ['key' => null], 'key'],
+                [['key' => new stdClass], ['key' => []], ['key' => null], 'key'],
                 ['key' => [['string']]]
             );
             $this->fail();

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -306,6 +306,18 @@ final class FiltererTest extends TestCase
     /**
      * @test
      * @covers ::filter
+     */
+    public function filterThrowsExceptionOnInvalidResponseType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'responseType' was not a recognized value");
+
+        Filterer::filter([], [], ['responseType' => 'invalid']);
+    }
+
+    /**
+     * @test
+     * @covers ::filter
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage filters for field 'boo' was not a array
      */

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -216,6 +216,12 @@ final class FiltererTest extends TestCase
                 'options' => [],
                 'result' => [true, ['field' => 'I'], null, []],
             ],
+            'redact alias' => [
+                'spec' => ['field' => [['redact', ['other'], '*']]],
+                'input' => ['field' => 'one or other'],
+                'options' => [],
+                'result' => [true, ['field' => 'one or *****'], null, []],
+            ],
         ];
     }
 

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -228,6 +228,26 @@ final class FiltererTest extends TestCase
     /**
      * @test
      * @covers ::filter
+     */
+    public function filterReturnsResponseType()
+    {
+        $specification = ['id' => [['uint']]];
+        $input = ['id' => 1];
+        $options = ['responseType' => Filterer::RESPONSE_TYPE_FILTER];
+
+        $result = Filterer::filter($specification, $input, $options);
+
+        $this->assertInstanceOf(FilterResponse::class, $result);
+        $this->assertSame(true, $result->success);
+        $this->assertSame($input, $result->filteredValue);
+        $this->assertSame([], $result->errors);
+        $this->assertSame(null, $result->errorMessage);
+        $this->assertSame([], $result->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::filter
      * @covers ::setFilterAliases
      */
     public function filterCustomShortNamePass()

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -248,6 +248,26 @@ final class FiltererTest extends TestCase
     /**
      * @test
      * @covers ::filter
+     */
+    public function filterReturnsResponseTypeWithErrors()
+    {
+        $specification = ['name' => [['string']]];
+        $input = ['name' => 'foo', 'id' => 1];
+        $options = ['responseType' => Filterer::RESPONSE_TYPE_FILTER];
+
+        $result = Filterer::filter($specification, $input, $options);
+
+        $this->assertInstanceOf(FilterResponse::class, $result);
+        $this->assertSame(false, $result->success);
+        $this->assertSame(['name' => 'foo'], $result->filteredValue);
+        $this->assertSame(['id' => "Field 'id' with value '1' is unknown"], $result->errors);
+        $this->assertSame("Field 'id' with value '1' is unknown", $result->errorMessage);
+        $this->assertSame(['id' => 1], $result->unknowns);
+    }
+
+    /**
+     * @test
+     * @covers ::filter
      * @covers ::setFilterAliases
      */
     public function filterCustomShortNamePass()


### PR DESCRIPTION
#### What does this PR do?
This pull request adds a new `FilterResponse` class and adds a `responseType` option to the `Filterer::filter` function to allow an instance of this new class to be returned.

The default return is still an array, which means it is not backwards-breaking. Additionally, the `FilterResponse` object can be converted to the traditional array result with its `toArray()` function.

Example use:
```php
$response = Filterer::filter($spec, $value, ['responseType' => Filterer::RESPONSE_TYPE_FILTER]);
if ($response->success === false) {
  if (isset($response->errors['id']) {
    // do something different
  }

  $errorCount = count($response->errors);
  throw new FilterException("{$errorCount} errors encountered: {$response->errorMessage}");
}

return $response->filteredValue;
```

#### Checklist
- [X] Pull request contains a clear definition of changes
- [X] Tests (either unit, integration, or acceptance) written and passing
- [X] Relevant documentation produced and/or updated

