### PR TITLE
Add returnOnNull filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The filter specification for a single field is also an array.  It can contain tw
   result.  The `required` value does not affect `default` behavior.
 * `error` defines a custom error message to be returned if the value fails filtering. Within the error string, `{value}` can be used as a placeholder
   for the value that failed filtering.
+* `returnOnNull` defines whether the filter should continue on null values or return null when it is found in the filter chain. The default for this option is `false`
 
 The rest of the specification for the field are the filters to apply.
 

--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -23,4 +23,9 @@ final class FilterOptions
      * @var string
      */
     const CONFLICTS_WITH = 'conflictsWith';
+
+    /**
+     * @var string
+     */
+    const RETURN_ON_NULL = 'returnOnNull';
 }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -131,6 +131,8 @@ final class Filterer implements FiltererInterface
             unset($filters[FilterOptions::IS_REQUIRED]);//doesn't matter if required since we have this one
             unset($filters[FilterOptions::DEFAULT_VALUE]);//doesn't matter if there is a default since we have a value
             $conflicts = self::extractConflicts($filters, $field, $conflicts);
+            $returnOnNull = $filters['returnOnNull'] ?? false;
+            unset($filters['returnOnNull']);
 
             foreach ($filters as $filter) {
                 self::assertFilterIsNotArray($filter, $field);
@@ -147,6 +149,9 @@ final class Filterer implements FiltererInterface
                 array_unshift($filter, $input);
                 try {
                     $input = call_user_func_array($function, $filter);
+                    if ($input === null && $returnOnNull) {
+                        break;
+                    }
                 } catch (Exception $exception) {
                     $errors = self::handleCustomError($field, $input, $exception, $errors, $customError);
                     continue 2;//next field

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -131,8 +131,7 @@ final class Filterer implements FiltererInterface
             unset($filters[FilterOptions::IS_REQUIRED]);//doesn't matter if required since we have this one
             unset($filters[FilterOptions::DEFAULT_VALUE]);//doesn't matter if there is a default since we have a value
             $conflicts = self::extractConflicts($filters, $field, $conflicts);
-            $returnOnNull = $filters['returnOnNull'] ?? false;
-            unset($filters['returnOnNull']);
+            $returnOnNull = self::extractReturnOnNull($filters, $field);
 
             foreach ($filters as $filter) {
                 self::assertFilterIsNotArray($filter, $field);
@@ -220,6 +219,13 @@ final class Filterer implements FiltererInterface
         }
 
         return $errors;
+    }
+
+    private static function extractReturnOnNull(array &$filters, string $field) : bool
+    {
+        $returnOnNull = $filters[FilterOptions::RETURN_ON_NULL] ?? false;
+        unset($filters[FilterOptions::RETURN_ON_NULL]);
+        return $returnOnNull;
     }
 
     /**

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -43,11 +43,21 @@ final class Filterer implements FiltererInterface
     ];
 
     /**
+     * @var bool
+     */
+    const DEFAULT_ALLOW_UNKNOWNS = false;
+
+    /**
+     * @var bool
+     */
+    const DEFAULT_REQUIRED = false;
+
+    /**
      * @var array
      */
     const DEFAULT_OPTIONS = [
-        FiltererOptions::ALLOW_UNKNOWNS => false,
-        FiltererOptions::DEFAULT_REQUIRED => false,
+        FiltererOptions::ALLOW_UNKNOWNS => self::DEFAULT_ALLOW_UNKNOWNS,
+        FiltererOptions::DEFAULT_REQUIRED => self::DEFAULT_REQUIRED,
         FiltererOptions::RESPONSE_TYPE => self::RESPONSE_TYPE_ARRAY,
     ];
 

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -297,7 +297,7 @@ final class FiltererTest extends TestCase
                 ],
             ],
             'returnOnNull filter option' => [
-                'spec' => ['field' => ['returnOnNull' => true, ['string', true], ['string']]],
+                'spec' => ['field' => [FilterOptions::RETURN_ON_NULL => true, ['string', true], ['string']]],
                 'input' => ['field' => null],
                 'options' => [],
                 'result' => [true, ['field' => null], null, []],

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -296,6 +296,12 @@ final class FiltererTest extends TestCase
                     [],
                 ],
             ],
+            'returnOnNull filter option' => [
+                'spec' => ['field' => ['returnOnNull' => true, ['string', true], ['string']]],
+                'input' => ['field' => null],
+                'options' => [],
+                'result' => [true, ['field' => null], null, []],
+            ],
         ];
     }
 


### PR DESCRIPTION
#### What does this PR do?
This pull request adds a `returnOnNull` option which will break the filter chain and return null if a null value is found anywhere within the chain.

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [x] Relevant documentation produced and/or updated

