### PR TITLE
Add "conflictsWith" functionality to Filterer library

### DIFF
--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -18,4 +18,9 @@ final class FilterOptions
      * @var string
      */
     const IS_REQUIRED = 'required';
+
+    /**
+     * @var string
+     */
+    const CONFLICTS_WITH = 'conflictsWith';
 }

--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TraderInteractive;
+
+final class FilterOptions
+{
+    /**
+     * @var string
+     */
+    const DEFAULT_VALUE = 'default';
+
+    /**
+     * @var string
+     */
+    const CUSTOM_ERROR = 'error';
+
+    /**
+     * @var string
+     */
+    const IS_REQUIRED = 'required';
+}

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -46,9 +46,9 @@ final class Filterer implements FiltererInterface
      * @var array
      */
     const DEFAULT_OPTIONS = [
-        'allowUnknowns' => false,
-        'defaultRequired' => false,
-        'responseType' => self::RESPONSE_TYPE_ARRAY,
+        FiltererOptions::ALLOW_UNKNOWNS => false,
+        FiltererOptions::DEFAULT_REQUIRED => false,
+        FiltererOptions::RESPONSE_TYPE => self::RESPONSE_TYPE_ARRAY,
     ];
 
     /**
@@ -219,8 +219,8 @@ final class Filterer implements FiltererInterface
     private function getOptions() : array
     {
         return [
-            'defaultRequired' => $this->defaultRequired,
-            'allowUnknowns' => $this->allowUnknowns,
+            FiltererOptions::DEFAULT_REQUIRED => $this->defaultRequired,
+            FiltererOptions::ALLOW_UNKNOWNS => $this->allowUnknowns,
         ];
     }
 
@@ -296,7 +296,7 @@ final class Filterer implements FiltererInterface
     public static function filter(array $specification, array $input, array $options = [])
     {
         $options += self::DEFAULT_OPTIONS;
-        $responseType = $options['responseType'];
+        $responseType = $options[FiltererOptions::RESPONSE_TYPE];
 
         $filterer = new Filterer($specification, $options);
         $filterResponse = $filterer->execute($input);
@@ -561,9 +561,9 @@ final class Filterer implements FiltererInterface
 
     private static function getAllowUnknowns(array $options) : bool
     {
-        $allowUnknowns = $options['allowUnknowns'];
+        $allowUnknowns = $options[FiltererOptions::ALLOW_UNKNOWNS];
         if ($allowUnknowns !== false && $allowUnknowns !== true) {
-            throw new InvalidArgumentException("'allowUnknowns' option was not a bool");
+            throw new InvalidArgumentException(sprintf("'%s' option was not a bool", FiltererOptions::ALLOW_UNKNOWNS));
         }
 
         return $allowUnknowns;
@@ -571,9 +571,11 @@ final class Filterer implements FiltererInterface
 
     private static function getDefaultRequired(array $options) : bool
     {
-        $defaultRequired = $options['defaultRequired'];
+        $defaultRequired = $options[FiltererOptions::DEFAULT_REQUIRED];
         if ($defaultRequired !== false && $defaultRequired !== true) {
-            throw new InvalidArgumentException("'defaultRequired' option was not a bool");
+            throw new InvalidArgumentException(
+                sprintf("'%s' option was not a bool", FiltererOptions::DEFAULT_REQUIRED)
+            );
         }
 
         return $defaultRequired;
@@ -602,6 +604,6 @@ final class Filterer implements FiltererInterface
             ];
         }
 
-        throw new InvalidArgumentException("'responseType' was not a recognized value");
+        throw new InvalidArgumentException(sprintf("'%s' was not a recognized value", FiltererOptions::RESPONSE_TYPE));
     }
 }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -127,8 +127,8 @@ final class Filterer implements FiltererInterface
             $filters = $this->specification[$field];
             self::assertFiltersIsAnArray($filters, $field);
             $customError = self::validateCustomError($filters, $field);
-            unset($filters['required']);//doesn't matter if required since we have this one
-            unset($filters['default']);//doesn't matter if there is a default since we have a value
+            unset($filters[FilterOptions::IS_REQUIRED]);//doesn't matter if required since we have this one
+            unset($filters[FilterOptions::DEFAULT_VALUE]);//doesn't matter if there is a default since we have a value
             foreach ($filters as $filter) {
                 self::assertFilterIsNotArray($filter, $field);
 
@@ -156,8 +156,8 @@ final class Filterer implements FiltererInterface
         foreach ($leftOverSpec as $field => $filters) {
             self::assertFiltersIsAnArray($filters, $field);
             $required = self::getRequired($filters, $this->defaultRequired, $field);
-            if (array_key_exists('default', $filters)) {
-                $inputToFilter[$field] = $filters['default'];
+            if (array_key_exists(FilterOptions::DEFAULT_VALUE, $filters)) {
+                $inputToFilter[$field] = $filters[FilterOptions::DEFAULT_VALUE];
                 continue;
             }
 
@@ -484,9 +484,11 @@ final class Filterer implements FiltererInterface
 
     private static function getRequired($filters, $defaultRequired, $field) : bool
     {
-        $required = isset($filters['required']) ? $filters['required'] : $defaultRequired;
+        $required = $filters[FilterOptions::IS_REQUIRED] ?? $defaultRequired;
         if ($required !== false && $required !== true) {
-            throw new InvalidArgumentException("'required' for field '{$field}' was not a bool");
+            throw new InvalidArgumentException(
+                sprintf("'%s' for field '%s' was not a bool", FilterOptions::IS_REQUIRED, $field)
+            );
         }
 
         return $required;
@@ -547,13 +549,15 @@ final class Filterer implements FiltererInterface
     private static function validateCustomError(array &$filters, string $field)
     {
         $customError = null;
-        if (array_key_exists('error', $filters)) {
-            $customError = $filters['error'];
+        if (array_key_exists(FilterOptions::CUSTOM_ERROR, $filters)) {
+            $customError = $filters[FilterOptions::CUSTOM_ERROR];
             if (!is_string($customError) || trim($customError) === '') {
-                throw new InvalidArgumentException("error for field '{$field}' was not a non-empty string");
+                throw new InvalidArgumentException(
+                    sprintf("%s for field '%s' was not a non-empty string", FilterOptions::CUSTOM_ERROR, $field)
+                );
             }
 
-            unset($filters['error']);//unset so its not used as a filter
+            unset($filters[FilterOptions::CUSTOM_ERROR]);//unset so its not used as a filter
         }
 
         return $customError;

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -548,11 +548,8 @@ final class Filterer implements FiltererInterface
     ) : array {
         $error = $customError;
         if ($error === null) {
-            $error = sprintf(
-                "Field '%s' with value '{value}' failed filtering, message '%s'",
-                $field,
-                $e->getMessage()
-            );
+            $errorFormat = "Field '%s' with value '{value}' failed filtering, message '%s'";
+            $error = sprintf($errorFormat, $field, $e->getMessage());
         }
 
         $errors[$field] = str_replace('{value}', trim(var_export($value, true), "'"), $error);

--- a/src/FiltererOptions.php
+++ b/src/FiltererOptions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TraderInteractive;
+
+final class FiltererOptions
+{
+    /**
+     * @var string
+     */
+    const ALLOW_UNKNOWNS = 'allowUnknowns';
+
+    /**
+     * @var string
+     */
+    const DEFAULT_REQUIRED = 'defaultRequired';
+
+    /**
+     * @var string
+     */
+    const RESPONSE_TYPE = 'responseType';
+}

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -238,6 +238,64 @@ final class FiltererTest extends TestCase
                 'options' => [],
                 'result' => [true, ['field' => 'a string with newlines and extra spaces'], null, []],
             ],
+            'conflicts with single' => [
+                'spec' => [
+                    'fieldOne' => [FilterOptions::CONFLICTS_WITH => 'fieldThree', ['string']],
+                    'fieldTwo' => [['string']],
+                    'fieldThree' => [FilterOptions::CONFLICTS_WITH => 'fieldOne', ['string']],
+                ],
+                'input' => [
+                    'fieldOne' => 'abc',
+                    'fieldTwo' => '123',
+                    'fieldThree' => 'xyz',
+                ],
+                'options' => [],
+                'result' => [
+                    false,
+                    null,
+                    "Field 'fieldOne' cannot be given if field 'fieldThree' is present.\n"
+                    . "Field 'fieldThree' cannot be given if field 'fieldOne' is present.",
+                    [],
+                ],
+            ],
+            'conflicts with multiple' => [
+                'spec' => [
+                    'fieldOne' => [FilterOptions::CONFLICTS_WITH => ['fieldTwo', 'fieldThree'], ['string']],
+                    'fieldTwo' => [['string']],
+                    'fieldThree' => [['string']],
+                ],
+                'input' => [
+                    'fieldOne' => 'abc',
+                    'fieldTwo' => '123',
+                ],
+                'options' => [],
+                'result' => [
+                    false,
+                    null,
+                    "Field 'fieldOne' cannot be given if field 'fieldTwo' is present.",
+                    [],
+                ],
+            ],
+            'conflicts with not present' => [
+                'spec' => [
+                    'fieldOne' => [FilterOptions::CONFLICTS_WITH => 'fieldThree', ['string']],
+                    'fieldTwo' => [['string']],
+                ],
+                'input' => [
+                    'fieldOne' => 'abc',
+                    'fieldTwo' => '123',
+                ],
+                'options' => [],
+                'result' => [
+                    true,
+                    [
+                        'fieldOne' => 'abc',
+                        'fieldTwo' => '123',
+                    ],
+                    null,
+                    [],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the `confictsWith` filter option which allows a user to specify that the given filtered value conflicts with one or more filtered values. If multiple conflicting values are present a `FilterException` is raised.
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

