### PR TITLE
Add FilterOptions::THROW_ON_ERROR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.0",
         "phpunit/phpunit": "^6.0",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.2",
+        "symfony/yaml": "^3.4"
     },
     "autoload": {
         "psr-4": { "TraderInteractive\\": "src/" }

--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -28,4 +28,9 @@ final class FilterOptions
      * @var string
      */
     const USES = 'uses';
+
+    /**
+     * @var string
+     */
+    const THROW_ON_ERROR = 'throwOnError';
 }

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -5,6 +5,7 @@ namespace TraderInteractive;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use stdClass;
 use Throwable;
 use TraderInteractive\Exceptions\FilterException;
@@ -378,6 +379,47 @@ final class FiltererTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     */
+    public function executeThrowsOnError()
+    {
+        $exception = new RuntimeException('the error');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($exception->getMessage());
+        $filter = function () use ($exception) {
+            throw $exception;
+        };
+
+        $specification = [
+            'id' => [
+                FilterOptions::THROW_ON_ERROR => true,
+                [$filter],
+            ],
+        ];
+        $filterer = new Filterer($specification);
+        $filterer->execute(['id' => 1]);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     */
+    public function executeValidatesThrowsOnError()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(Filterer::INVALID_THROW_ON_ERROR_VALUE_ERROR_FORMAT, 'id'));
+        $specification = [
+            'id' => [
+                FilterOptions::THROW_ON_ERROR => 'abc',
+                ['uint'],
+            ],
+        ];
+        $filterer = new Filterer($specification);
+        $filterer->execute(['id' => 1]);
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the option `FilterOptions::THROW_ON_ERROR` which will bypass the filterer response and throw an exception if one occurs.
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated

