### PR TITLE
Add FilterOptions::RETURN_ON_NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,46 @@ $specification = [
 
 The exponent filter spec will call the PHP function `pow()` with the value provided and the result of the filtered `base`
 
+## throwOnError
+
+#### Summary
+
+If true the Filterer will throw any exception caught when filtering a value instead of returning the error in the filter response.
+
+#### Types
+
+   * boolean
+   
+#### Default   
+
+The default value for this option is `false`
+
+#### Constant
+
+```php
+TraderInteractive\FilterOptions::THROW_ON_ERROR
+```
+
+#### Example
+
+```php
+$idFilter = function ($id) : int {
+    if (!is_int($id)) {
+       throw new NotFoundException("id '{$id}' was not found"); 
+    }
+    
+    return $id;
+};
+$specification = [
+    'id' => [
+        \TraderInteractive\FilterOptions::THROW_ON_ERROR => true,
+        [$idFilter],
+    ],
+];
+```
+
+If the `id` value given in the input is not an integer the Filterer::execute() will throw the `NotFoundException`
+
 ### Included Filters
 Of course, any function can potentially be used as a filter, but we include some useful filters with aliases for common circumstances.
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,42 @@ $specification = [
 
 If the `id` value given in the input is not an integer the Filterer::execute() will throw the `NotFoundException`
 
+## returnOnNull
+
+#### Summary
+
+Flag to break the filter chain if a resulting value is `null` Useful for nullable fields which require additional filtering if the value is not null.
+
+#### Types
+
+   * boolean
+   
+#### Default   
+
+The default value for this option is `false`
+
+#### Constant
+
+```php
+TraderInteractive\FilterOptions::RETURN_ON_NULL
+```
+
+#### Example
+
+```php
+$validCodes = ['A', 'I', 'X'];
+$specification = [
+    'code' => [
+        \TraderInteractive\FilterOptions::RETURN_ON_NULL => true,
+        ['string', true],
+        ['strtoupper'],
+        ['in', $validCodes],
+    ],
+];
+```
+
+If the `code` value is `null` then the resulting filtered value will be null. Otherwise the value must be one of the `$validCode` values.
+
 ### Included Filters
 Of course, any function can potentially be used as a filter, but we include some useful filters with aliases for common circumstances.
 

--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -27,6 +27,11 @@ final class FilterOptions
     /**
      * @var string
      */
+    const RETURN_ON_NULL = 'returnOnNull';
+
+    /**
+     * @var string
+     */
     const THROW_ON_ERROR = 'throwOnError';
 
     /**

--- a/src/FilterOptions.php
+++ b/src/FilterOptions.php
@@ -7,7 +7,7 @@ final class FilterOptions
     /**
      * @var string
      */
-    const DEFAULT_VALUE = 'default';
+    const CONFLICTS_WITH = 'conflictsWith';
 
     /**
      * @var string
@@ -17,20 +17,20 @@ final class FilterOptions
     /**
      * @var string
      */
+    const DEFAULT_VALUE = 'default';
+
+    /**
+     * @var string
+     */
     const IS_REQUIRED = 'required';
 
     /**
      * @var string
      */
-    const CONFLICTS_WITH = 'conflictsWith';
+    const THROW_ON_ERROR = 'throwOnError';
 
     /**
      * @var string
      */
     const USES = 'uses';
-
-    /**
-     * @var string
-     */
-    const THROW_ON_ERROR = 'throwOnError';
 }

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -64,9 +64,7 @@ final class Filterer implements FiltererInterface
     /**
      * @var string
      */
-    const INVALID_THROW_ON_ERROR_VALUE_ERROR_FORMAT = (
-        FilterOptions::THROW_ON_ERROR . " for field '%s' was not a boolean value"
-    );
+    const INVALID_BOOLEAN_FILTER_OPTION = "%s for field '%s' was not a boolean value";
 
     /**
      * @var array
@@ -623,7 +621,7 @@ final class Filterer implements FiltererInterface
         $throwOnError = $filters[FilterOptions::THROW_ON_ERROR];
         if ($throwOnError !== true && $throwOnError !== false) {
             throw new InvalidArgumentException(
-                sprintf(self::INVALID_THROW_ON_ERROR_VALUE_ERROR_FORMAT, $field)
+                sprintf(self::INVALID_BOOLEAN_FILTER_OPTION, FilterOptions::THROW_ON_ERROR, $field)
             );
         }
 

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -411,7 +411,9 @@ final class FiltererTest extends TestCase
     public function executeValidatesThrowsOnError()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(Filterer::INVALID_THROW_ON_ERROR_VALUE_ERROR_FORMAT, 'id'));
+        $this->expectExceptionMessage(
+            sprintf(Filterer::INVALID_BOOLEAN_FILTER_OPTION, FilterOptions::THROW_ON_ERROR, 'id')
+        );
         $specification = [
             'id' => [
                 FilterOptions::THROW_ON_ERROR => 'abc',

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -378,6 +378,12 @@ final class FiltererTest extends TestCase
                     [],
                 ],
             ],
+            'returnOnNull filter option' => [
+                'spec' => ['field' => [FilterOptions::RETURN_ON_NULL => true, ['string', true], ['string']]],
+                'input' => ['field' => null],
+                'options' => [],
+                'result' => [true, ['field' => null], null, []],
+            ],
         ];
     }
 
@@ -417,6 +423,26 @@ final class FiltererTest extends TestCase
         $specification = [
             'id' => [
                 FilterOptions::THROW_ON_ERROR => 'abc',
+                ['uint'],
+            ],
+        ];
+        $filterer = new Filterer($specification);
+        $filterer->execute(['id' => 1]);
+    }
+
+    /**
+     * @test
+     * @covers ::execute
+     */
+    public function executeValidatesReturnOnNull()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf(Filterer::INVALID_BOOLEAN_FILTER_OPTION, FilterOptions::RETURN_ON_NULL, 'id')
+        );
+        $specification = [
+            'id' => [
+                FilterOptions::RETURN_ON_NULL => 'abc',
                 ['uint'],
             ],
         ];


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the `returnOnNull` filter option. This option will break filter chaining if a resulting filtered value is null.
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated

