### PR TITLE
Add filterer alias for TimeOfDayFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,15 @@ $value = \TraderInteractive\Filter\PhoneFilter::filter('234.567.8901', false, '(
 assert($value === '(234) 567-8901');
 ```
 
+#### TimeOfDayFilter::filter
+Aliased in the filterer as `time-of-day`, this will filter a given string value as a time of day in `HH:MM:SS` format.
+
+The following ensures that `$value` is a valid `HH:MM:SS` formatted string.
+```php
+$value = \TraderInteractive\Filter\TimeOfDayFilter::filter('12:15:23');
+assert($value === '12:15:23');
+```
+
 #### XmlFilter::filter
 Aliased in the filter as `xml`, this will ensure the given string value is valid XML, returning the original value.
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "traderinteractive/exceptions": "^1.2",
         "traderinteractive/filter-arrays": "^3.2",
         "traderinteractive/filter-bools": "^3.0",
-        "traderinteractive/filter-dates": "^3.0",
+        "traderinteractive/filter-dates": "^3.1",
         "traderinteractive/filter-floats": "^3.0",
         "traderinteractive/filter-ints": "^3.0",
         "traderinteractive/filter-strings": "^3.5"

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -9,6 +9,7 @@ use TraderInteractive\Exceptions\FilterException;
 use TraderInteractive\Filter\Arrays;
 use TraderInteractive\Filter\Json;
 use TraderInteractive\Filter\PhoneFilter;
+use TraderInteractive\Filter\TimeOfDayFilter;
 use TraderInteractive\Filter\XmlFilter;
 
 /**
@@ -46,6 +47,7 @@ final class Filterer implements FiltererInterface
         'redact' => '\\TraderInteractive\\Filter\\Strings::redact',
         'string' => '\\TraderInteractive\\Filter\\Strings::filter',
         'strip-tags' => '\\TraderInteractive\\Filter\\Strings::stripTags',
+        'time-of-day' => TimeOfDayFilter::class . '::filter',
         'timezone' => '\\TraderInteractive\\Filter\\DateTimeZone::filter',
         'translate' => '\\TraderInteractive\\Filter\\Strings::translate',
         'uint' => '\\TraderInteractive\\Filter\\UnsignedInt::filter',

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -515,6 +515,23 @@ final class FiltererTest extends TestCase
                     [],
                 ],
             ],
+            'time-of-day' => [
+                'spec' => [
+                    'field' => [['time-of-day']],
+                ],
+                'input' => [
+                    'field' => '23:59:59',
+                ],
+                'options' => [],
+                'result' => [
+                    true,
+                    [
+                        'field' => '23:59:59',
+                    ],
+                    null,
+                    [],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
#### What does this PR do?
* Update requirement for traderinteractive/filter-dates
* Add filterer alias for TimeOfDayFilter::filter
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

