### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -29,17 +29,17 @@
     },
     "license": "MIT",
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.2",
-        "traderinteractive/filter-arrays": "^3.2",
-        "traderinteractive/filter-bools": "^3.0",
-        "traderinteractive/filter-dates": "^3.1",
-        "traderinteractive/filter-floats": "^3.0",
-        "traderinteractive/filter-ints": "^3.0",
-        "traderinteractive/filter-strings": "^3.5"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0",
+        "traderinteractive/filter-arrays": "^4.0",
+        "traderinteractive/filter-bools": "^4.0",
+        "traderinteractive/filter-dates": "^4.0",
+        "traderinteractive/filter-floats": "^4.0",
+        "traderinteractive/filter-ints": "^4.0",
+        "traderinteractive/filter-strings": "^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2",
         "symfony/yaml": "^3.4"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,11 @@
-<phpunit colors="true" forceCoversAnnotation="true">
-    <testsuite name="Unit Tests">
-        <directory>./tests</directory>
-    </testsuite>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuite name="Unit Tests">
+    <directory>./tests</directory>
+  </testsuite>
 </phpunit>

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -44,7 +44,7 @@ final class FiltererTest extends TestCase
         . "</books>\n"
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         Filterer::setFilterAliases(Filterer::DEFAULT_FILTER_ALIASES);
     }
@@ -690,11 +690,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException Exception
-     * @expectedExceptionMessage Function 'boo' for field 'foo' is not callable
      */
     public function notCallable()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Function 'boo' for field 'foo' is not callable");
         Filterer::filter(['foo' => [['boo']]], ['foo' => 0]);
     }
 
@@ -702,11 +702,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage 'allowUnknowns' option was not a bool
      */
     public function allowUnknownsNotBool()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'allowUnknowns' option was not a bool");
         Filterer::filter([], [], ['allowUnknowns' => 1]);
     }
 
@@ -714,11 +714,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage 'defaultRequired' option was not a bool
      */
     public function defaultRequiredNotBool()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'defaultRequired' option was not a bool");
         Filterer::filter([], [], ['defaultRequired' => 1]);
     }
 
@@ -739,11 +739,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage filters for field 'boo' was not a array
      */
     public function filtersNotArrayInLeftOverSpec()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("filters for field 'boo' was not a array");
         Filterer::filter(['boo' => 1], []);
     }
 
@@ -751,11 +751,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage filters for field 'boo' was not a array
      */
     public function filtersNotArrayWithInput()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("filters for field 'boo' was not a array");
         Filterer::filter(['boo' => 1], ['boo' => 'notUnderTest']);
     }
 
@@ -763,11 +763,11 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage filter for field 'boo' was not a array
      */
     public function filterNotArray()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("filter for field 'boo' was not a array");
         Filterer::filter(['boo' => [1]], ['boo' => 'notUnderTest']);
     }
 
@@ -775,33 +775,33 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage 'required' for field 'boo' was not a bool
      */
     public function requiredNotBool()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'required' for field 'boo' was not a bool");
         Filterer::filter(['boo' => ['required' => 1]], []);
     }
 
     /**
      * @test
      * @covers ::registerAlias
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage $alias was not a string or int
      */
     public function registerAliasAliasNotString()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$alias was not a string or int');
         Filterer::registerAlias(true, 'strtolower');
     }
 
     /**
      * @test
      * @covers ::registerAlias
-     * @expectedException Exception
-     * @expectedExceptionMessage Alias 'upper' exists
      */
     public function registerExistingAliasOverwriteFalse()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Alias 'upper' exists");
         Filterer::setFilterAliases([]);
         Filterer::registerAlias('upper', 'strtoupper');
         Filterer::registerAlias('upper', 'strtoupper', false);
@@ -834,13 +834,13 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage error for field 'fieldOne' was not a non-empty string
      *
      * @return void
      */
     public function filterWithNonStringError()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("error for field 'fieldOne' was not a non-empty string");
         Filterer::filter(
             ['fieldOne' => [['strtoupper'], 'error' => new stdClass()]],
             ['fieldOne' => 'valueOne']
@@ -853,13 +853,13 @@ final class FiltererTest extends TestCase
      * @test
      * @covers ::filter
      * @covers ::execute
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage error for field 'fieldOne' was not a non-empty string
      *
      * @return void
      */
     public function filterWithEmptyStringError()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("error for field 'fieldOne' was not a non-empty string");
         Filterer::filter(
             ['fieldOne' => [['strtoupper'], 'error' => "\n   \t"]],
             ['fieldOne' => 'valueOne']
@@ -907,9 +907,9 @@ final class FiltererTest extends TestCase
 Field '1' with value 'array (
 )' failed filtering, message 'Value 'array (
 )' is not a string'
-Field '2' with value 'stdClass::__set_state(array(
-))' failed filtering, message 'Value 'stdClass::__set_state(array(
-))' is not a string'
+Field '2' with value '(object) array(
+)' failed filtering, message 'Value '(object) array(
+)' is not a string'
 TXT;
             $this->assertSame($expected, $e->getMessage());
         }
@@ -965,9 +965,9 @@ TXT;
             $this->fail();
         } catch (FilterException $e) {
             $expected = <<<TXT
-Field 'key' with value 'stdClass::__set_state(array(
-))' failed filtering, message 'Value 'stdClass::__set_state(array(
-))' is not a string'
+Field 'key' with value '(object) array(
+)' failed filtering, message 'Value '(object) array(
+)' is not a string'
 Field 'key' with value 'array (
 )' failed filtering, message 'Value 'array (
 )' is not a string'


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

