### PR TITLE
Add alias for Arrays::implode

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -500,6 +500,20 @@ $result = $filterer->execute($input);
 assert(['field' => [['FOO_VALUE' => 123, 'BAR_VALUE' => 'abc'], ['FOO_VALUE' => 456, 'BAR_VALUE' => 'def']]], $result->filteredValue);
 ```
 
+#### Arrays::implode
+
+Aliased in the filterer as `implode`, this filter is a wrapper around `implode` to ensure proper argument order.
+
+```php
+$sepcification = ['field' => [['array'],['implode', ',']]];
+$filterer = new TraderInteractive\Filterer($specification);
+$input = [
+    'field' => ['lastname', 'email', 'phone'],
+];
+$result = $filterer->execute($input);
+assert(['field' => 'lastname,email,phone'], $result->filteredValue);
+```
+
 #### Arrays::in
 Aliased in the filterer as `in`, this filter is a wrapper around `in_array` including support for strict equality testing.
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "traderinteractive/exceptions": "^2.0",
-        "traderinteractive/filter-arrays": "^4.0",
+        "traderinteractive/filter-arrays": "^4.1",
         "traderinteractive/filter-bools": "^4.0",
         "traderinteractive/filter-dates": "^4.0",
         "traderinteractive/filter-floats": "^4.0",

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -36,6 +36,7 @@ final class Filterer implements FiltererInterface
         'explode' => '\\TraderInteractive\\Filter\\Strings::explode',
         'flatten' => '\\TraderInteractive\\Filter\\Arrays::flatten',
         'float' => '\\TraderInteractive\\Filter\\Floats::filter',
+        'implode' => Arrays::class . '::implode',
         'in' => '\\TraderInteractive\\Filter\\Arrays::in',
         'int' => '\\TraderInteractive\\Filter\\Ints::filter',
         'json' => Json::class . '::validate',

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -532,6 +532,24 @@ final class FiltererTest extends TestCase
                     [],
                 ],
             ],
+            'implode' => [
+                'spec' => [
+                    'field' => [['array'], ['implode', ',']],
+                ],
+                'input' => [
+                    'field' => ['one', 'two', 'three'],
+                ],
+                'options' => [],
+                'result' => [
+                    true,
+                    [
+                        'field' => 'one,two,three',
+                    ],
+                    null,
+                    [],
+                ],
+
+            ],
         ];
     }
 


### PR DESCRIPTION
#### What does this PR do?
* Add PHP 8.3 to build matrix
* Add filterer alias `implode` for the `Arrays::implode` filter
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

