### PR TITLE
Add UUID Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,16 @@ $value = \TraderInteractive\Filter\TimeOfDayFilter::filter('12:15:23');
 assert($value === '12:15:23');
 ```
 
+#### UuidFilter::filter
+Aliased in the filterer as `uuid`, this will filter a given string values as a valid UUID.
+
+The following ensures the `$value` is a valid UUID v4 formatted string. Disallowing null values, nil UUIDs and UUID version other than v4
+
+```php
+$value = \TraderInteractive\Filter\UuidFilter::filter('2c02b87a-97ec-4de0-8c50-6721a29c150f', false, false, [4]);
+assert($value === '2c02b87a-97ec-4de0-8c50-6721a29c150f');
+```
+
 #### XmlFilter::filter
 Aliased in the filter as `xml`, this will ensure the given string value is valid XML, returning the original value.
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "traderinteractive/filter-dates": "^4.0",
         "traderinteractive/filter-floats": "^4.0",
         "traderinteractive/filter-ints": "^4.0",
-        "traderinteractive/filter-strings": "^4.0"
+        "traderinteractive/filter-strings": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -10,6 +10,7 @@ use TraderInteractive\Filter\Arrays;
 use TraderInteractive\Filter\Json;
 use TraderInteractive\Filter\PhoneFilter;
 use TraderInteractive\Filter\TimeOfDayFilter;
+use TraderInteractive\Filter\UuidFilter;
 use TraderInteractive\Filter\XmlFilter;
 
 /**
@@ -54,6 +55,7 @@ final class Filterer implements FiltererInterface
         'translate' => '\\TraderInteractive\\Filter\\Strings::translate',
         'uint' => '\\TraderInteractive\\Filter\\UnsignedInt::filter',
         'url' => '\\TraderInteractive\\Filter\\Url::filter',
+        'uuid' => UuidFilter::class . '::filter',
         'xml' => XmlFilter::class . '::filter',
         'xml-extract' => XmlFilter::class . '::extract',
         'xml-validate' => XmlFilter::class . '::validate',

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -548,7 +548,23 @@ final class FiltererTest extends TestCase
                     null,
                     [],
                 ],
-
+            ],
+            'uuid' => [
+                'spec' => [
+                    'field' => [['uuid', false, false, [4]]],
+                ],
+                'input' => [
+                    'field' => '2c02b87a-97ec-4de0-8c50-6721a29c150f',
+                ],
+                'options' => [],
+                'result' => [
+                    true,
+                    [
+                        'field' => '2c02b87a-97ec-4de0-8c50-6721a29c150f',
+                    ],
+                    null,
+                    [],
+                ],
             ],
         ];
     }


### PR DESCRIPTION
#### What does this PR do?
* Updates requirement for `traderinteractive/filter-strings`
* Adds `uuid` filterer alias
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

