### PR TITLE
AGI-1181: Add 'strip-emoji' filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,13 @@ $value = \TraderInteractive\Filter\Strings::explode('abc,def,ghi');
 assert($value === ['abc', 'def', 'ghi']);
 ```
 
+#### Strings::stripEmoji
+Aliased in the filterer as `strip-emoji`, this filter removes emoji characters from a given string optionally replacing them with the given replacement string
+```php
+$value = \TraderInteractive\Filter\Strings::stripEmoji('this is ridiculous🙄', '!');
+assert($value === 'this is ridiculous!');
+```
+
 #### Strings::stripTags
 Aliased in the filterer as `strip-tags`, this filter is essentially a wrapper around the built-in [`strip_tags`](http://php.net/manual/en/function.strip-tags.php) function. However, unlike the
 native function the stripTags method will return null when given a null value.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "traderinteractive/filter-dates": "^3.1",
         "traderinteractive/filter-floats": "^3.0",
         "traderinteractive/filter-ints": "^3.0",
-        "traderinteractive/filter-strings": "^3.6"
+        "traderinteractive/filter-strings": "^3.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Filterer.php
+++ b/src/Filterer.php
@@ -9,6 +9,7 @@ use TraderInteractive\Exceptions\FilterException;
 use TraderInteractive\Filter\Arrays;
 use TraderInteractive\Filter\Json;
 use TraderInteractive\Filter\PhoneFilter;
+use TraderInteractive\Filter\Strings;
 use TraderInteractive\Filter\TimeOfDayFilter;
 use TraderInteractive\Filter\UuidFilter;
 use TraderInteractive\Filter\XmlFilter;
@@ -47,6 +48,7 @@ final class Filterer implements FiltererInterface
         'phone' => PhoneFilter::class . '::filter',
         'redact' => '\\TraderInteractive\\Filter\\Strings::redact',
         'string' => '\\TraderInteractive\\Filter\\Strings::filter',
+        'strip-emoji' => Strings::class . '::stripEmoji',
         'strip-tags' => '\\TraderInteractive\\Filter\\Strings::stripTags',
         'time-of-day' => TimeOfDayFilter::class . '::filter',
         'timezone' => '\\TraderInteractive\\Filter\\DateTimeZone::filter',

--- a/tests/FiltererTest.php
+++ b/tests/FiltererTest.php
@@ -549,6 +549,25 @@ final class FiltererTest extends TestCase
                     [],
                 ],
             ],
+            'strip-emoji' => [
+                'spec' => [
+                    'field' => [['strip-emoji']],
+                ],
+                'input' => [
+                    'field' => 'This 💩 text contains 😞 multiple emoji 🍔 characters 🍚. As well as an alphanumeric '
+                    . 'supplement 🆗 and flag 🚩',
+                ],
+                'options' => [],
+                'result' => [
+                    true,
+                    [
+                        'field' => 'This  text contains  multiple emoji  characters . As well as an alphanumeric '
+                        . 'supplement  and flag ',
+                    ],
+                    null,
+                    [],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
#### What does this PR do?
This pull request updates the requirement for `traderinteractive/filter-strings` and adds the `strip-emoji` filter as an available alias
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

